### PR TITLE
Update CMakeLists file for modern compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,12 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.10.0)
 project(BurstingGraphMining)
 SET(NLOPT_LIBRARY "/usr/local/lib/libnlopt.so")
 SET(NLOPT_LIBRARIES "/usr/local/lib/libnlopt.so.0" "/usr/local/lib/libnlopt.so.0.10.0")
 
-find_package(Boost REQUIRED COMPONENTS graph)
+find_package(Boost REQUIRED COMPONENTS graph CONFIG)
 find_package(NLopt REQUIRED)
 
 include_directories(
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_SOURCE_DIR}/include
 )
 
@@ -16,13 +15,13 @@ add_library(burst_graph STATIC burst_graph/burst_graph.cpp)
 
 # Link the burst_graph library to your executables
 add_executable(rush main.cpp)
-target_link_libraries(rush burst_graph ${Boost_LIBRARIES})
+target_link_libraries(rush burst_graph Boost::graph)
 
 add_executable(load_test test/load_graph_test.cpp)
-target_link_libraries(load_test burst_graph ${Boost_LIBRARIES})
+target_link_libraries(load_test burst_graph Boost::graph)
 
 add_executable(peeling_test test/peeling_test.cpp)
-target_link_libraries(peeling_test burst_graph ${Boost_LIBRARIES})
+target_link_libraries(peeling_test burst_graph Boost::graph)
 
 add_executable(output_test test/output_dense_subgraph.cpp)
-target_link_libraries(output_test burst_graph ${Boost_LIBRARIES})
+target_link_libraries(output_test burst_graph Boost::graph)


### PR DESCRIPTION
Change `cmake_minimum_required` to version 3.10.0 for a long-term compatibility, as version 3.5.0 is required since 4.0. Change usage of CMake's `FindBoost` module to Boost's upstream `BoostConfig.cmake` provided since it's 1.70 version.